### PR TITLE
Make StringIterator take a `*const String` instead of a `*String`

### DIFF
--- a/zig-string.zig
+++ b/zig-string.zig
@@ -395,7 +395,7 @@ pub const String = struct {
     // Iterator support
     pub usingnamespace struct {
         pub const StringIterator = struct {
-            string: *String,
+            string: *const String,
             index: usize,
 
             pub fn next(it: *StringIterator) ?[]const u8 {
@@ -410,7 +410,7 @@ pub const String = struct {
             }
         };
 
-        pub fn iterator(self: *String) StringIterator {
+        pub fn iterator(self: *const String) StringIterator {
             return StringIterator{
                 .string = self,
                 .index = 0,


### PR DESCRIPTION
This fixes a compile issue i was hitting in my code when trying to call `.iterator()` on a string object
```
┌─[beyley@arch] - [~/Projects/PROGRAMMING/Zig/zvmf] - [2023-02-19 11:28:39]
└─[1] <git:(master+✈) > zig build test
src/main.zig:237:43: error: expected type '*zig-string.zig-string.String', found '*const zig-string.zig-string.String'
            var iterator = property_string.iterator();
                           ~~~~~~~~~~~~~~~^~~~~~~~~
src/main.zig:237:43: note: cast discards const qualifier
src/zig-string/zig-string.zig:413:31: note: parameter type declared here
        pub fn iterator(self: *String) StringIterator {
                              ^~~~~~~
``` 
and StringIterator doesnt modify its underlying `String` object so this shouldnt be a breaking change(?)