### PR TITLE
Init with contents

### DIFF
--- a/zig-string-tests.zig
+++ b/zig-string-tests.zig
@@ -174,3 +174,16 @@ test "String Tests" {
 
     assert(i == myStr.len());
 }
+
+test "init with contents" {
+    // Allocator for the String
+    const page_allocator = std.heap.page_allocator;
+    var arena = std.heap.ArenaAllocator.init(page_allocator);
+    defer arena.deinit();
+
+    var initial_contents = "String with initial contents!";
+
+    // This is how we create the String with contents at the start
+    var myStr = try String.init_with_contents(arena.allocator(), initial_contents);
+    assert(eql(u8, myStr.str(), initial_contents));
+}

--- a/zig-string.zig
+++ b/zig-string.zig
@@ -26,6 +26,14 @@ pub const String = struct {
         };
     }
 
+    pub fn init_with_contents(allocator: std.mem.Allocator, contents: []const u8) Error!String {
+        var string = init(allocator);
+
+        try string.concat(contents);
+
+        return string;
+    }
+
     /// Deallocates the internal buffer
     pub fn deinit(self: *String) void {
         if (self.buffer) |buffer| self.allocator.free(buffer);


### PR DESCRIPTION
Allows you to initialize a string with contents already inside, allowing some code to be cleaner