### PR TITLE
Replaced `std.debug.assert` with `std.testing.expect`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /zig-cache/
+/.zig-cache/
 /zig-out/
 /NUL

--- a/zig-string-tests.zig
+++ b/zig-string-tests.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 const ArenaAllocator = std.heap.ArenaAllocator;
-const eql = std.mem.eql;
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
+const expectEqualStrings = std.testing.expectEqualStrings;
 
 const zig_string = @import("./zig-string.zig");
 const String = zig_string.String;
@@ -36,13 +37,13 @@ test "String Tests" {
 
     // allocate & capacity
     try myStr.allocate(16);
-    try expect(myStr.capacity() == 16);
-    try expect(myStr.size == 0);
+    try expectEqual(myStr.capacity(), 16);
+    try expectEqual(myStr.size, 0);
 
     // truncate
     try myStr.truncate();
-    try expect(myStr.capacity() == myStr.size);
-    try expect(myStr.capacity() == 0);
+    try expectEqual(myStr.capacity(), myStr.size);
+    try expectEqual(myStr.capacity(), 0);
 
     // concat
     try myStr.concat("A");
@@ -50,33 +51,33 @@ test "String Tests" {
     try myStr.concat("💯");
     try myStr.concat("Hello🔥");
 
-    try expect(myStr.size == 17);
+    try expectEqual(myStr.size, 17);
 
     // pop & length
-    try expect(myStr.len() == 9);
-    try expect(eql(u8, myStr.pop().?, "🔥"));
-    try expect(myStr.len() == 8);
-    try expect(eql(u8, myStr.pop().?, "o"));
-    try expect(myStr.len() == 7);
+    try expectEqual(myStr.len(), 9);
+    try expectEqualStrings(myStr.pop().?, "🔥");
+    try expectEqual(myStr.len(), 8);
+    try expectEqualStrings(myStr.pop().?, "o");
+    try expectEqual(myStr.len(), 7);
 
     // str & cmp
     try expect(myStr.cmp("A\u{5360}💯Hell"));
     try expect(myStr.cmp(myStr.str()));
 
     // charAt
-    try expect(eql(u8, myStr.charAt(2).?, "💯"));
-    try expect(eql(u8, myStr.charAt(1).?, "\u{5360}"));
-    try expect(eql(u8, myStr.charAt(0).?, "A"));
+    try expectEqualStrings(myStr.charAt(2).?, "💯");
+    try expectEqualStrings(myStr.charAt(1).?, "\u{5360}");
+    try expectEqualStrings(myStr.charAt(0).?, "A");
 
     // insert
     try myStr.insert("🔥", 1);
-    try expect(eql(u8, myStr.charAt(1).?, "🔥"));
+    try expectEqualStrings(myStr.charAt(1).?, "🔥");
     try expect(myStr.cmp("A🔥\u{5360}💯Hell"));
 
     // find
-    try expect(myStr.find("🔥").? == 1);
-    try expect(myStr.find("💯").? == 3);
-    try expect(myStr.find("Hell").? == 4);
+    try expectEqual(myStr.find("🔥").?, 1);
+    try expectEqual(myStr.find("💯").?, 3);
+    try expectEqual(myStr.find("Hell").?, 4);
 
     // remove & removeRange
     try myStr.removeRange(0, 3);
@@ -115,26 +116,26 @@ test "String Tests" {
     try expect(!myStr.isEmpty());
 
     // split
-    try expect(eql(u8, myStr.split("💯", 0).?, ""));
-    try expect(eql(u8, myStr.split("💯", 1).?, "Hello"));
-    try expect(eql(u8, myStr.split("💯", 2).?, ""));
-    try expect(eql(u8, myStr.split("💯", 3).?, "Hello"));
-    try expect(eql(u8, myStr.split("💯", 5).?, "Hello"));
-    try expect(eql(u8, myStr.split("💯", 6).?, ""));
+    try expectEqualStrings(myStr.split("💯", 0).?, "");
+    try expectEqualStrings(myStr.split("💯", 1).?, "Hello");
+    try expectEqualStrings(myStr.split("💯", 2).?, "");
+    try expectEqualStrings(myStr.split("💯", 3).?, "Hello");
+    try expectEqualStrings(myStr.split("💯", 5).?, "Hello");
+    try expectEqualStrings(myStr.split("💯", 6).?, "");
 
     var splitStr = String.init(arena.allocator());
     defer splitStr.deinit();
 
     try splitStr.concat("variable='value'");
-    try expect(eql(u8, splitStr.split("=", 0).?, "variable"));
-    try expect(eql(u8, splitStr.split("=", 1).?, "'value'"));
+    try expectEqualStrings(splitStr.split("=", 0).?, "variable");
+    try expectEqualStrings(splitStr.split("=", 1).?, "'value'");
 
     // splitToString
     var newSplit = try splitStr.splitToString("=", 0);
     try expect(newSplit != null);
     defer newSplit.?.deinit();
 
-    try expect(eql(u8, newSplit.?.str(), "variable"));
+    try expectEqualStrings(newSplit.?.str(), "variable");
 
     // toLowercase & toUppercase
     myStr.toUppercase();
@@ -149,17 +150,17 @@ test "String Tests" {
 
     // clear
     myStr.clear();
-    try expect(myStr.len() == 0);
-    try expect(myStr.size == 0);
+    try expectEqual(myStr.len(), 0);
+    try expectEqual(myStr.size, 0);
 
     // writer
     const writer = myStr.writer();
     const length = try writer.write("This is a Test!");
-    try expect(length == 15);
+    try expectEqual(length, 15);
 
     // owned
     const mySlice = try myStr.toOwned();
-    try expect(eql(u8, mySlice.?, "This is a Test!"));
+    try expectEqualStrings(mySlice.?, "This is a Test!");
     arena.allocator().free(mySlice.?);
 
     // StringIterator
@@ -167,12 +168,12 @@ test "String Tests" {
     var iter = myStr.iterator();
     while (iter.next()) |ch| {
         if (i == 0) {
-            try expect(eql(u8, "T", ch));
+            try expectEqualStrings("T", ch);
         }
         i += 1;
     }
 
-    try expect(i == myStr.len());
+    try expectEqual(i, myStr.len());
 
     // setStr
     const contents = "setStr Test!";
@@ -180,7 +181,7 @@ test "String Tests" {
     try expect(myStr.cmp(contents));
 
     // non ascii supports in windows
-    // try expect(std.os.windows.kernel32.GetConsoleOutputCP() == 65001);
+    // try expectEqual(std.os.windows.kernel32.GetConsoleOutputCP(), 65001);
 }
 
 test "init with contents" {
@@ -193,7 +194,7 @@ test "init with contents" {
 
     // This is how we create the String with contents at the start
     var myStr = try String.init_with_contents(arena.allocator(), initial_contents);
-    try expect(eql(u8, myStr.str(), initial_contents));
+    try expectEqualStrings(myStr.str(), initial_contents);
 }
 
 test "startsWith Tests" {
@@ -236,7 +237,7 @@ test "replace Tests" {
     try myString.concat("hi,how are you");
     var result = try myString.replace("hi,", "");
     try expect(result);
-    try expect(eql(u8, myString.str(), "how are you"));
+    try expectEqualStrings(myString.str(), "how are you");
 
     result = try myString.replace("abc", " ");
     try expect(!result);
@@ -244,7 +245,7 @@ test "replace Tests" {
     myString.clear();
     try myString.concat("💯hello💯💯hello💯💯hello💯");
     _ = try myString.replace("hello", "hi");
-    try expect(eql(u8, myString.str(), "💯hi💯💯hi💯💯hi💯"));
+    try expectEqualStrings(myString.str(), "💯hi💯💯hi💯💯hi💯");
 }
 
 test "rfind Tests" {
@@ -254,5 +255,5 @@ test "rfind Tests" {
     var myString = try String.init_with_contents(arena.allocator(), "💯hi💯💯hi💯💯hi💯");
     defer myString.deinit();
 
-    try expect(myString.rfind("hi") == 9);
+    try expectEqual(myString.rfind("hi"), 9);
 }

--- a/zig-string-tests.zig
+++ b/zig-string-tests.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const ArenaAllocator = std.heap.ArenaAllocator;
-const assert = std.debug.assert;
 const eql = std.mem.eql;
+const expect = std.testing.expect;
 
 const zig_string = @import("./zig-string.zig");
 const String = zig_string.String;
@@ -21,7 +21,7 @@ test "Basic Usage" {
     try myString.concat(", World 🔥");
 
     // Success!
-    assert(myString.cmp("🔥 Hello, World 🔥"));
+    try expect(myString.cmp("🔥 Hello, World 🔥"));
 }
 
 test "String Tests" {
@@ -36,13 +36,13 @@ test "String Tests" {
 
     // allocate & capacity
     try myStr.allocate(16);
-    assert(myStr.capacity() == 16);
-    assert(myStr.size == 0);
+    try expect(myStr.capacity() == 16);
+    try expect(myStr.size == 0);
 
     // truncate
     try myStr.truncate();
-    assert(myStr.capacity() == myStr.size);
-    assert(myStr.capacity() == 0);
+    try expect(myStr.capacity() == myStr.size);
+    try expect(myStr.capacity() == 0);
 
     // concat
     try myStr.concat("A");
@@ -50,116 +50,116 @@ test "String Tests" {
     try myStr.concat("💯");
     try myStr.concat("Hello🔥");
 
-    assert(myStr.size == 17);
+    try expect(myStr.size == 17);
 
     // pop & length
-    assert(myStr.len() == 9);
-    assert(eql(u8, myStr.pop().?, "🔥"));
-    assert(myStr.len() == 8);
-    assert(eql(u8, myStr.pop().?, "o"));
-    assert(myStr.len() == 7);
+    try expect(myStr.len() == 9);
+    try expect(eql(u8, myStr.pop().?, "🔥"));
+    try expect(myStr.len() == 8);
+    try expect(eql(u8, myStr.pop().?, "o"));
+    try expect(myStr.len() == 7);
 
     // str & cmp
-    assert(myStr.cmp("A\u{5360}💯Hell"));
-    assert(myStr.cmp(myStr.str()));
+    try expect(myStr.cmp("A\u{5360}💯Hell"));
+    try expect(myStr.cmp(myStr.str()));
 
     // charAt
-    assert(eql(u8, myStr.charAt(2).?, "💯"));
-    assert(eql(u8, myStr.charAt(1).?, "\u{5360}"));
-    assert(eql(u8, myStr.charAt(0).?, "A"));
+    try expect(eql(u8, myStr.charAt(2).?, "💯"));
+    try expect(eql(u8, myStr.charAt(1).?, "\u{5360}"));
+    try expect(eql(u8, myStr.charAt(0).?, "A"));
 
     // insert
     try myStr.insert("🔥", 1);
-    assert(eql(u8, myStr.charAt(1).?, "🔥"));
-    assert(myStr.cmp("A🔥\u{5360}💯Hell"));
+    try expect(eql(u8, myStr.charAt(1).?, "🔥"));
+    try expect(myStr.cmp("A🔥\u{5360}💯Hell"));
 
     // find
-    assert(myStr.find("🔥").? == 1);
-    assert(myStr.find("💯").? == 3);
-    assert(myStr.find("Hell").? == 4);
+    try expect(myStr.find("🔥").? == 1);
+    try expect(myStr.find("💯").? == 3);
+    try expect(myStr.find("Hell").? == 4);
 
     // remove & removeRange
     try myStr.removeRange(0, 3);
-    assert(myStr.cmp("💯Hell"));
+    try expect(myStr.cmp("💯Hell"));
     try myStr.remove(myStr.len() - 1);
-    assert(myStr.cmp("💯Hel"));
+    try expect(myStr.cmp("💯Hel"));
 
     const whitelist = [_]u8{ ' ', '\t', '\n', '\r' };
 
     // trimStart
     try myStr.insert("      ", 0);
     myStr.trimStart(whitelist[0..]);
-    assert(myStr.cmp("💯Hel"));
+    try expect(myStr.cmp("💯Hel"));
 
     // trimEnd
     _ = try myStr.concat("lo💯\n      ");
     myStr.trimEnd(whitelist[0..]);
-    assert(myStr.cmp("💯Hello💯"));
+    try expect(myStr.cmp("💯Hello💯"));
 
     // clone
     var testStr = try myStr.clone();
     defer testStr.deinit();
-    assert(testStr.cmp(myStr.str()));
+    try expect(testStr.cmp(myStr.str()));
 
     // reverse
     myStr.reverse();
-    assert(myStr.cmp("💯olleH💯"));
+    try expect(myStr.cmp("💯olleH💯"));
     myStr.reverse();
-    assert(myStr.cmp("💯Hello💯"));
+    try expect(myStr.cmp("💯Hello💯"));
 
     // repeat
     try myStr.repeat(2);
-    assert(myStr.cmp("💯Hello💯💯Hello💯💯Hello💯"));
+    try expect(myStr.cmp("💯Hello💯💯Hello💯💯Hello💯"));
 
     // isEmpty
-    assert(!myStr.isEmpty());
+    try expect(!myStr.isEmpty());
 
     // split
-    assert(eql(u8, myStr.split("💯", 0).?, ""));
-    assert(eql(u8, myStr.split("💯", 1).?, "Hello"));
-    assert(eql(u8, myStr.split("💯", 2).?, ""));
-    assert(eql(u8, myStr.split("💯", 3).?, "Hello"));
-    assert(eql(u8, myStr.split("💯", 5).?, "Hello"));
-    assert(eql(u8, myStr.split("💯", 6).?, ""));
+    try expect(eql(u8, myStr.split("💯", 0).?, ""));
+    try expect(eql(u8, myStr.split("💯", 1).?, "Hello"));
+    try expect(eql(u8, myStr.split("💯", 2).?, ""));
+    try expect(eql(u8, myStr.split("💯", 3).?, "Hello"));
+    try expect(eql(u8, myStr.split("💯", 5).?, "Hello"));
+    try expect(eql(u8, myStr.split("💯", 6).?, ""));
 
     var splitStr = String.init(arena.allocator());
     defer splitStr.deinit();
 
     try splitStr.concat("variable='value'");
-    assert(eql(u8, splitStr.split("=", 0).?, "variable"));
-    assert(eql(u8, splitStr.split("=", 1).?, "'value'"));
+    try expect(eql(u8, splitStr.split("=", 0).?, "variable"));
+    try expect(eql(u8, splitStr.split("=", 1).?, "'value'"));
 
     // splitToString
     var newSplit = try splitStr.splitToString("=", 0);
-    assert(newSplit != null);
+    try expect(newSplit != null);
     defer newSplit.?.deinit();
 
-    assert(eql(u8, newSplit.?.str(), "variable"));
+    try expect(eql(u8, newSplit.?.str(), "variable"));
 
     // toLowercase & toUppercase
     myStr.toUppercase();
-    assert(myStr.cmp("💯HELLO💯💯HELLO💯💯HELLO💯"));
+    try expect(myStr.cmp("💯HELLO💯💯HELLO💯💯HELLO💯"));
     myStr.toLowercase();
-    assert(myStr.cmp("💯hello💯💯hello💯💯hello💯"));
+    try expect(myStr.cmp("💯hello💯💯hello💯💯hello💯"));
 
     // substr
     var subStr = try myStr.substr(0, 7);
     defer subStr.deinit();
-    assert(subStr.cmp("💯hello💯"));
+    try expect(subStr.cmp("💯hello💯"));
 
     // clear
     myStr.clear();
-    assert(myStr.len() == 0);
-    assert(myStr.size == 0);
+    try expect(myStr.len() == 0);
+    try expect(myStr.size == 0);
 
     // writer
     const writer = myStr.writer();
     const length = try writer.write("This is a Test!");
-    assert(length == 15);
+    try expect(length == 15);
 
     // owned
     const mySlice = try myStr.toOwned();
-    assert(eql(u8, mySlice.?, "This is a Test!"));
+    try expect(eql(u8, mySlice.?, "This is a Test!"));
     arena.allocator().free(mySlice.?);
 
     // StringIterator
@@ -167,20 +167,20 @@ test "String Tests" {
     var iter = myStr.iterator();
     while (iter.next()) |ch| {
         if (i == 0) {
-            assert(eql(u8, "T", ch));
+            try expect(eql(u8, "T", ch));
         }
         i += 1;
     }
 
-    assert(i == myStr.len());
+    try expect(i == myStr.len());
 
     // setStr
     const contents = "setStr Test!";
     try myStr.setStr(contents);
-    assert(myStr.cmp(contents));
+    try expect(myStr.cmp(contents));
 
     // non ascii supports in windows
-    // assert(std.os.windows.kernel32.GetConsoleOutputCP() == 65001);
+    // try expect(std.os.windows.kernel32.GetConsoleOutputCP() == 65001);
 }
 
 test "init with contents" {
@@ -193,7 +193,7 @@ test "init with contents" {
 
     // This is how we create the String with contents at the start
     var myStr = try String.init_with_contents(arena.allocator(), initial_contents);
-    assert(eql(u8, myStr.str(), initial_contents));
+    try expect(eql(u8, myStr.str(), initial_contents));
 }
 
 test "startsWith Tests" {
@@ -204,8 +204,8 @@ test "startsWith Tests" {
     defer myString.deinit();
 
     try myString.concat("bananas");
-    assert(myString.startsWith("bana"));
-    assert(!myString.startsWith("abc"));
+    try expect(myString.startsWith("bana"));
+    try expect(!myString.startsWith("abc"));
 }
 
 test "endsWith Tests" {
@@ -216,13 +216,13 @@ test "endsWith Tests" {
     defer myString.deinit();
 
     try myString.concat("asbananas");
-    assert(myString.endsWith("nas"));
-    assert(!myString.endsWith("abc"));
+    try expect(myString.endsWith("nas"));
+    try expect(!myString.endsWith("abc"));
 
     try myString.truncate();
     try myString.concat("💯hello💯💯hello💯💯hello💯");
     std.debug.print("", .{});
-    assert(myString.endsWith("hello💯"));
+    try expect(myString.endsWith("hello💯"));
 }
 
 test "replace Tests" {
@@ -235,16 +235,16 @@ test "replace Tests" {
 
     try myString.concat("hi,how are you");
     var result = try myString.replace("hi,", "");
-    assert(result);
-    assert(eql(u8, myString.str(), "how are you"));
+    try expect(result);
+    try expect(eql(u8, myString.str(), "how are you"));
 
     result = try myString.replace("abc", " ");
-    assert(!result);
+    try expect(!result);
 
     myString.clear();
     try myString.concat("💯hello💯💯hello💯💯hello💯");
     _ = try myString.replace("hello", "hi");
-    assert(eql(u8, myString.str(), "💯hi💯💯hi💯💯hi💯"));
+    try expect(eql(u8, myString.str(), "💯hi💯💯hi💯💯hi💯"));
 }
 
 test "rfind Tests" {
@@ -254,5 +254,5 @@ test "rfind Tests" {
     var myString = try String.init_with_contents(arena.allocator(), "💯hi💯💯hi💯💯hi💯");
     defer myString.deinit();
 
-    assert(myString.rfind("hi") == 9);
+    try expect(myString.rfind("hi") == 9);
 }


### PR DESCRIPTION
`std.debug.assert` should not be used in tests, as it produces unclear error messages. This PR replaces all instances of `assert` with `try expect`.