### PR TITLE
Add `splitAll` and `splitAllToStrings` methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ If there are any issues with <b>complexity</b> please <b>open an issue</b>
 | removeRange        | Removes a range of characters                                            |
 | repeat             | Repeats string n times                                                   |
 | reverse            | Reverses all the characters                                              |
-| split              | Returns a slice based on delimiters                                      |
-| splitToString      | Returns a String based on delimiters                                     |
+| split              | Returns a slice based on delimiters and index                            |
+| splitAll           | Returns a slice of slices based on delimiters                            |
+| splitToString      | Returns a String based on delimiters and index                           |
+| splitAllToStrings  | Returns a slice of Strings based on delimiters                           |
 | lines              | Returns a slice of Strings split by newlines                             |
 | str                | Returns the String as a slice                                            |
 | substr             | Creates a string from a range                                            |

--- a/zig-string-tests.zig
+++ b/zig-string-tests.zig
@@ -130,12 +130,33 @@ test "String Tests" {
     try expectEqualStrings(splitStr.split("=", 0).?, "variable");
     try expectEqualStrings(splitStr.split("=", 1).?, "'value'");
 
+    // splitAll
+    const splitAllStr = try String.init_with_contents(arena.allocator(), "THIS IS A  TEST");
+    const splitAllSlices = try splitAllStr.splitAll(" ");
+
+    try expectEqual(splitAllSlices.len, 5);
+    try expectEqualStrings(splitAllSlices[0], "THIS");
+    try expectEqualStrings(splitAllSlices[1], "IS");
+    try expectEqualStrings(splitAllSlices[2], "A");
+    try expectEqualStrings(splitAllSlices[3], "");
+    try expectEqualStrings(splitAllSlices[4], "TEST");
+
     // splitToString
     var newSplit = try splitStr.splitToString("=", 0);
     try expect(newSplit != null);
     defer newSplit.?.deinit();
 
     try expectEqualStrings(newSplit.?.str(), "variable");
+
+    // splitAllToStrings
+    const splitAllStrings = try splitAllStr.splitAllToStrings(" ");
+
+    try expectEqual(splitAllStrings.len, 5);
+    try expectEqualStrings(splitAllStrings[0].str(), "THIS");
+    try expectEqualStrings(splitAllStrings[1].str(), "IS");
+    try expectEqualStrings(splitAllStrings[2].str(), "A");
+    try expectEqualStrings(splitAllStrings[3].str(), "");
+    try expectEqualStrings(splitAllStrings[4].str(), "TEST");
 
     // lines
     const lineSlice = "Line0\r\nLine1\nLine2";

--- a/zig-string.zig
+++ b/zig-string.zig
@@ -361,6 +361,19 @@ pub const String = struct {
         return null;
     }
 
+    /// Splits the String into slices, based on a delimiter.
+    pub fn splitAll(self: *const String, delimiters: []const u8) ![][]const u8 {
+        var splitArr = std.ArrayList([]const u8).init(std.heap.page_allocator);
+        defer splitArr.deinit();
+
+        var i: usize = 0;
+        while (self.split(delimiters, i)) |slice| : (i += 1) {
+            try splitArr.append(slice);
+        }
+
+        return try splitArr.toOwnedSlice();
+    }
+
     /// Splits the String into a new string, based on delimiters and an index
     /// The user of this function is in charge of the memory of the new String.
     pub fn splitToString(self: *const String, delimiters: []const u8, index: usize) Error!?String {
@@ -373,6 +386,20 @@ pub const String = struct {
         return null;
     }
 
+    /// Splits the String into a slice of new Strings, based on delimiters.
+    /// The user of this function is in charge of the memory of the new Strings.
+    pub fn splitAllToStrings(self: *const String, delimiters: []const u8) ![]String {
+        var splitArr = std.ArrayList(String).init(std.heap.page_allocator);
+        defer splitArr.deinit();
+
+        var i: usize = 0;
+        while (try self.splitToString(delimiters, i)) |splitStr| : (i += 1) {
+            try splitArr.append(splitStr);
+        }
+
+        return try splitArr.toOwnedSlice();
+    }
+
     /// Splits the String into a slice of Strings by new line (\r\n or \n).
     pub fn lines(self: *String) ![]String {
         var lineArr = std.ArrayList(String).init(std.heap.page_allocator);
@@ -383,12 +410,7 @@ pub const String = struct {
 
         _ = try selfClone.replace("\r\n", "\n");
 
-        var i: usize = 0;
-        while (try selfClone.splitToString("\n", i)) |line| : (i += 1) {
-            try lineArr.append(line);
-        }
-
-        return try lineArr.toOwnedSlice();
+        return try selfClone.splitAllToStrings("\n");
     }
 
     /// Clears the contents of the String but leaves the capacity


### PR DESCRIPTION
Implements two methods `splitAll` and `splitAllToStrings` which splits a string into a slice of slices or Strings respectively based on a delimiter. Also modifies `lines` to use `splitAllToStrings`.