### PR TITLE
Feature: Implement includes

### DIFF
--- a/zig-string-tests.zig
+++ b/zig-string-tests.zig
@@ -280,3 +280,24 @@ test "toCapitalized Tests" {
 
     try expectEqualStrings(myString.str(), "Love And Be Loved");
 }
+
+test "includes Tests" {
+    var myString = try String.init_with_contents(std.testing.allocator, "love and be loved");
+    defer myString.deinit();
+
+    var needle = try String.init_with_contents(std.testing.allocator, "be");
+    defer needle.deinit();
+
+    try expect(myString.includesLiteral("and"));
+    try expect(myString.includesString(needle));
+
+    try needle.concat("t");
+
+    try expect(myString.includesLiteral("tiger") == false);
+    try expect(myString.includesString(needle) == false);
+
+    needle.clear();
+
+    try expect(myString.includesLiteral("") == false);
+    try expect(myString.includesString(needle) == false);
+}

--- a/zig-string.zig
+++ b/zig-string.zig
@@ -606,4 +606,38 @@ pub const String = struct {
         }
         return false;
     }
+
+    /// Checks if the needle String is within the source String
+    pub fn includesString(self: *String, needle: String) bool {
+
+        if (self.size == 0 or needle.size == 0) return false;
+
+        if (self.buffer) |buffer| {
+            if (needle.buffer) |needle_buffer| {
+                const found_index = std.mem.indexOf(u8, buffer[0..self.size], needle_buffer[0..needle.size]);
+
+                if (found_index == null) return false;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// Checks if the needle literal is within the source String
+    pub fn includesLiteral(self: *String, needle: []const u8) bool {
+
+        if (self.size == 0 or needle.len == 0) return false;
+
+        if (self.buffer) |buffer| {
+            const found_index = std.mem.indexOf(u8, buffer[0..self.size], needle);
+
+            if (found_index == null) return false;
+
+            return true;
+        }
+
+        return false;
+    }
 };


### PR DESCRIPTION
I have created the includes function that we had talked about. I saw that most of the functions deal with literals and not with other String types. I was not sure what was was needed and if there was a reason for that so I created one for a literal and one for a String type. It would be nice to have a single includes function that can take either but I was not exactly sure how to accomplish it, so I am open to ideas. Thanks.