### PR TITLE
Updated build.zig.zon for Ziglang 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-      .name = "zig-string",
-      .version = "0.9.0",
-      .paths = .{""},
+    .fingerprint = 0xd2ee692e004129ce,
+    .name = .zig_string,
+    .version = "0.9.0",
+    .paths = .{""},
 }
- 


### PR DESCRIPTION
This changes the type of .name, and adds .fingerprint, to build.zig.zon.

It is also worth noting that this also changes the name of the package to zig_string