### PR TITLE
Updated for compatility with zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-      .name = "zig-string",
-      .version = "0.9.0",
-      .paths = .{""},
+    .name = .zig_string,
+    .version = "0.10.0",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0xd2ee692e5a4bdae9,
+    .paths = .{""},
 }
- 


### PR DESCRIPTION
I updated the file zig.build.zon for compatibility with zig version 0.14.0:
- changed  .name to .zig_string ("zig-string" is not compatible anymore with zig version 0.14.0)
- changed .version to 0.10.0
- added .fingerprint with value suggested by zig build command
- added .minimum-zig-version to "0.14.0"

I tested with a local example on my Mac mini M4 by adding:
zig fetch --save git+https://github.com/flevin58/zig-string.git
